### PR TITLE
Fix/create user

### DIFF
--- a/src/components/AutentComp.vue
+++ b/src/components/AutentComp.vue
@@ -68,14 +68,19 @@ function onReset() {
 }
 const dominio = "@cujae.edu.cu";
 const createServiceInstance = new CreateService();
-const userData = {
-  name: name.value,
-  email: email.value + dominio,
-  password: password.value,
 
-};
 // Función de envío del formulario
-function onSubmit () {
+function onSubmit(e) {
+
+  e.preventDefault();
+
+  const userData = {
+    name: name.value,
+    email: email.value + dominio,
+    password: password.value,
+    role: role
+
+  };
 
   // Llama a la función createUser con los valores obtenidos
   createServiceInstance.createUser(userData)

--- a/src/services/CreateService.js
+++ b/src/services/CreateService.js
@@ -2,7 +2,7 @@ export default class CreateService {
 
   async createUser(userData) {
     try {
-      const response = await fetch('http://localhost:3000/user', {
+      const response = await fetch('http://localhost:5000/user', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
# Arreglada funcionalidad Create User

## Cambios en AutentComp.vue
- Se movió la declaración de la variable userData a dentro de la función onSubmit. Esto debido a que esta variable se creaba una sola vez con los primeros datos de name, email y password, y aunque estos últimos se actualizaran, userData no lo hacía porque ya estaba creada. Al pasarse dentro de onSubmit, userData se crea en demanda, o sea, cada vez que se llame onSubmit.
- Se agregó la propiedad `role` al objeto userData, ya que es requerido en la solicitud para crear un usuario

## Cambios en CreateService.ts
- Se cambio el puerto a 5000, ya que se estaba usando el 3000 en su lugar, mientras que la API corría por el puerto 5000.